### PR TITLE
Only highlight the user word where is a use statement

### DIFF
--- a/php-const.el
+++ b/php-const.el
@@ -473,7 +473,7 @@
       (1 font-lock-keyword-face) 
       (2 font-lock-type-face nil t))
 
-    '("\\\\\\(namespace\\|use \\)" (1 font-lock-type-face t t))
+    '("\\\\\\(namespace \\|use \\)" (1 font-lock-type-face t t))
     '("\\\\\\([^$]\\(\\sw+\\)\\)" (1 font-lock-type-face nil t))
 
     ;; class declaration


### PR DESCRIPTION
Now the mode highlight ever the word use include if is a part of other word, for example:

**use** **Use**rClass

I dont know wich is the correct branch to make the pull, is master is incorrect please notify me to re-pull.
