### PR TITLE
Do not force font-lock in php+-mode

### DIFF
--- a/php+-mode.el
+++ b/php+-mode.el
@@ -729,7 +729,6 @@ php+-mode, not including unittests or bundled packages."
 
   (setq c-special-indent-hook nil)
 
-  (turn-on-font-lock)
   (c-set-offset 'case-label '+)
   (c-set-offset 'cpp-macro 'php-cpp-macro-lineup)
   (c-set-offset 'arglist-intro 'php-arglist-intro-lineup)


### PR DESCRIPTION
User should enable/disable font-lock mode in his own configuration files instead.